### PR TITLE
allowing reserved columns as primary keys

### DIFF
--- a/bobby/src/handlers/run_handlers/db_deploy_utils/db_metadata_preparer.py
+++ b/bobby/src/handlers/run_handlers/db_deploy_utils/db_metadata_preparer.py
@@ -54,6 +54,8 @@ class DatabaseModelMetadataPreparer:
         self.model.add_metadata(Metadata.CLASSES, self._classes)
         self.model.add_metadata(Metadata.TYPE, self.model_type)
         self.model.add_metadata(Metadata.GENERIC_TYPE, ModelTypeMapper.get_model_type(self.model_type))
+        # Constant for every model
+        self.model.add_metadata(Metadata.RESERVED_COLUMNS, ['EVAL_TIME', 'CUR_USER', 'RUN_ID', 'PREDICTION'])
 
     def _prepare_spark(self):
         """

--- a/bobby/src/handlers/run_handlers/db_deploy_utils/db_model_ddl.py
+++ b/bobby/src/handlers/run_handlers/db_deploy_utils/db_model_ddl.py
@@ -158,7 +158,8 @@ class DatabaseModelDDL:
         pk_cols = ''
         for key in self.primary_key:
             # If pk is already in the schema_string, don't add another column. PK may be an existing value
-            if key.lower() not in schema_str.lower():
+            if key.lower() not in schema_str.lower() and \
+                    key.upper() not in self.model.get_metadata(Metadata.RESERVED_COLUMNS):
                 table_create_sql += f'{key} {self.primary_key[key]},'
             pk_cols += f'{key},'
 
@@ -186,7 +187,7 @@ class DatabaseModelDDL:
         inspector = peer_into_splice_db(SQLAlchemyClient.engine)
         table_cols = [col['name'] for col in inspector.get_columns(self.table_name, schema=self.schema_name)]
         reserved_fields = set(
-            ['CUR_USER', 'EVAL_TIME', 'RUN_ID', 'PREDICTION'] + (self.model.get_metadata(Metadata.CLASSES) or [])
+            self.model.get_metadata(Metadata.RESERVED_COLUMNS) + (self.model.get_metadata(Metadata.CLASSES) or [])
         )
         for col in table_cols:
             if col in reserved_fields:

--- a/shared/shared/models/model_types.py
+++ b/shared/shared/models/model_types.py
@@ -34,6 +34,7 @@ class Metadata:
     SQL_SCHEMA = 'sql_schema'
     SCHEMA_STR = 'schema_str'
     MODEL_VECTOR_STR = 'model_vector_str' # Like SCHEMA_STR but only columns that are in the feature vector
+    RESERVED_COLUMNS = 'reserved_columns' # For columns that come build into every model deployment table
 
 
 class H2OModelType(Enum):  # see https://bit.ly/3gJ69gc


### PR DESCRIPTION
The reserved columns that are created when you deploy a model into the database (EVAL_TIME, CUR_USER, PREDICTION, RUN_ID) can now be used at primary keys in the table