### PR TITLE
fix for k-means clustering and null training context

### DIFF
--- a/bobby/src/handlers/run_handlers/db_deploy_utils/preparation/spark_utils.py
+++ b/bobby/src/handlers/run_handlers/db_deploy_utils/preparation/spark_utils.py
@@ -50,7 +50,15 @@ class SparkUtils:
         """
         if hasattr(model, 'numClasses') or model.hasParam('numClasses'):
             return model.numClasses
-        return model.summary.k
+        elif hasattr(model, 'k'):
+            try:
+                return model.summary.k
+            except RuntimeError:
+                return model.getOrDefault('k')
+        else:
+            raise Exception('Unable to determine the number of classes of this model. If this is a model that should '
+                            'have classes, please raise an issue at https://github.com/splicemachine/pysplice/issues')
+
 
     @staticmethod
     def get_model_type(model):

--- a/shared/shared/models/feature_store_models.py
+++ b/shared/shared/models/feature_store_models.py
@@ -137,7 +137,7 @@ class TrainingSet(SQLAlchemyClient.SpliceBase):
     __table_args__ = {'schema': 'featurestore'}
     training_set_id: Column = Column(Integer, primary_key=True, autoincrement=True)
     name: Column = Column(String(255))
-    context_id: Column = Column(Integer, ForeignKey(TrainingContext.context_id))
+    context_id: Column = Column(Integer, ForeignKey(TrainingContext.context_id), nullable=True)
     last_update_ts: Column = Column(DateTime, server_default=(TextClause("CURRENT_TIMESTAMP")), nullable=False)
     last_update_username: Column = Column(String(128), nullable=False, server_default=TextClause("CURRENT_USER"))
 


### PR DESCRIPTION
Two fixes are addressed here that came from Sergio building out his new demo:
1. Certain types of K-Means clustering algorithms in SparkML do not have a "summary" but my code assumed that they did. I added a try/except and a new way to capture the value of k (the number of clusters).
2. In the Feature Store, some users will create a training dataset for modeling without the use of a Label, which removes the need for a "Training Context". These types of training sets should still be captured and logged, so I added the ability for the Training Context to be null.


I tested both of these fixes and everything runs clean locally and in k8s (tested on sales-gke-dev1)