### PR TITLE
DBAAS-5104: modify the get_feature_sets route to take names instead of IDs

### DIFF
--- a/feature_store/src/rest_api/routers/synchronous.py
+++ b/feature_store/src/rest_api/routers/synchronous.py
@@ -20,11 +20,12 @@ SYNC_ROUTER = APIRouter(
 
 @SYNC_ROUTER.get('/feature-sets', status_code=status.HTTP_200_OK, response_model=List[schemas.FeatureSet],
                 description="Returns a list of available feature sets", operation_id='get_feature_sets', tags=['Feature Sets'])
-async def get_feature_sets(fsid: Optional[List[int]] = Query(None), db: Session = Depends(crud.get_db)):
+async def get_feature_sets(names: Optional[List[str]] = Query([], alias="name"), db: Session = Depends(crud.get_db)):
     """
     Returns a list of available feature sets
     """
-    return crud.get_feature_sets(db, fsid)
+    crud.validate_feature_set_names(names)
+    return crud.get_feature_sets(db, feature_set_names=names)
 
 @SYNC_ROUTER.delete('/training-views', status_code=status.HTTP_200_OK,description="Removes a training view", 
                 operation_id='remove_training_view', tags=['Training Views'])
@@ -60,12 +61,12 @@ async def get_training_view_id(name: str, db: Session = Depends(crud.get_db)):
 
 @SYNC_ROUTER.get('/features', status_code=status.HTTP_200_OK, response_model=List[schemas.FeatureDescription],
                 description="Returns a list of all (or the specified) features", operation_id='get_features', tags=['Features'])
-async def get_features_by_name(name: List[str] = Query([]), db: Session = Depends(crud.get_db)):
+async def get_features_by_name(names: List[str] = Query([], alias="name"), db: Session = Depends(crud.get_db)):
     """
     Returns a list of features whose names are provided
 
     """
-    return crud.get_feature_descriptions_by_name(db, name)
+    return crud.get_feature_descriptions_by_name(db, names)
 
 @SYNC_ROUTER.delete('/feature-sets', status_code=status.HTTP_200_OK,
                 description="Removes a feature set", operation_id='remove_feature_set', tags=['Feature Sets'])
@@ -107,7 +108,7 @@ async def get_feature_vector_sql_from_training_view(features: List[schemas.Featu
 @SYNC_ROUTER.get('/feature-primary-keys', status_code=status.HTTP_200_OK, response_model=Dict[str, List[str]],
                 description="Returns a dictionary mapping each individual feature to its primary key(s).", 
                 operation_id='get_feature_primary_keys', tags=['Features'])
-async def get_feature_primary_keys(features: List[str] = Query([]), db: Session = Depends(crud.get_db)):
+async def get_feature_primary_keys(features: List[str] = Query([], alias="feature"), db: Session = Depends(crud.get_db)):
     """
     Returns a dictionary mapping each individual feature to its primary key(s). This function is not yet implemented.
     """


### PR DESCRIPTION
## Description
Allow users to pass in feature set names to get feature sets

## Motivation and Context
Users will not know the feature set ids 
Fixes [DBAAS-5104](https://splicemachine.atlassian.net/browse/DBAAS-5104)

## Dependencies
N/A

## How Has This Been Tested?
Endpoint tested in local environment against standalone db. Success case and failed cases all working as expected