### PR TITLE
Dbaas 5130

### DIFF
--- a/bobby/src/handlers/run_handlers/__init__.py
+++ b/bobby/src/handlers/run_handlers/__init__.py
@@ -1,6 +1,7 @@
 from .aws_deployment_handler import SageMakerDeploymentHandler
 from .azure_deployment_handler import AzureDeploymentHandler
 from .kubernetes_deployment_handler import KubernetesDeploymentHandler
+from .kubernetes_undeployment_handler import KubernetesUndeploymentHandler
 from .database_deployment_handler import DatabaseDeploymentHandler
 
 __author__: str = "Splice Machine, Inc."

--- a/bobby/src/handlers/run_handlers/kubernetes_undeployment_handler.py
+++ b/bobby/src/handlers/run_handlers/kubernetes_undeployment_handler.py
@@ -66,7 +66,7 @@ class KubernetesUndeploymentHandler(BaseDeploymentHandler):
             rendered_templates = check_output(['helm', 'template',
                                                f"{env_vars['SRC_HOME']}/configuration/k8s_serving_helm",
                                                "--values", tf.name])
-
+            self.logger.info("Using template to delete deployment", send_db=True)
             KubernetesAPIService.delete_from_yaml(data=rendered_templates)
 
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       SAGEMAKER_ROLE: ${SAGEMAKER_ROLE}
       MODE: production
       ENVIRONMENT: ${ENVIRONMENT}
-    image: splicemachine/sm_k8_bobby:0.1.27_undeploy_001
+    image: splicemachine/sm_k8_bobby:0.1.27
     build:
       args:
         server_image_tag: 0.0.15

--- a/mlflow/src/app/main.py
+++ b/mlflow/src/app/main.py
@@ -204,7 +204,7 @@ def initiate_job_rest() -> dict:
     """
     handler: Handler = KnownHandlers.MAPPING.get(request.json['handler_name'].upper())
     if not handler:
-        message: str = f"Handler {handler} is an unknown service"
+        message: str = f"Handler {request.json['handler_name']} is an unknown service"
         logger.error(message)
         return HTTP.responses['malformed'](create_json(status=APIStatuses.failure, message=message))
 

--- a/shared/shared/services/handlers.py
+++ b/shared/shared/services/handlers.py
@@ -104,7 +104,7 @@ class KnownHandlers:
             payload_args=[
                 Field('run_id'),
             ],
-            name=HandlerNames.deploy_k8s,
+            name=HandlerNames.undeploy_k8s,
             modifiable=True,
             url='/undeploy/kubernetes'
         )


### PR DESCRIPTION
undeploy_kubernetes function added to remove models from Kubernetes deployments


## Motivation and Context
Without this, models that were deployed to kubernetes always existed as pods which was annoying and wasted resources

## Dependencies
https://github.com/splicemachine/pysplice/pull/121

## How Has This Been Tested?
Deployed a model to Kubernetes
Undeployed it
Deleted the bobby pod, and made sure the model did not come back up

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/110014219-89c02b80-7cf0-11eb-928c-48b1b15f0857.png)
