### PR TITLE
DBAAS-5172:  fs.create_training_view Didn't fail when given an incorrect primary key

### DIFF
--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -606,7 +606,7 @@ def deploy_feature_set(db: Session, fset: schemas.FeatureSet) -> schemas.Feature
     logger.info('Done.')
     return fset
 
-def validate_training_view(db: Session, name, sql_text, join_keys, label_col=None) -> None:
+def validate_training_view(db: Session, name, sql_text, join_keys, pk_cols, label_col=None) -> None:
     """
     Validates that the training view doesn't already exist.
 
@@ -614,6 +614,7 @@ def validate_training_view(db: Session, name, sql_text, join_keys, label_col=Non
     :param name: The training view name
     :param sql: The training view provided SQL
     :param join_keys: The provided join keys when creating the training view
+    :param pk_cols: The primary keys of the training view
     :param label_col: The label column
     :return: None
     """
@@ -634,12 +635,20 @@ def validate_training_view(db: Session, name, sql_text, join_keys, label_col=Non
         raise e
 
     # Ensure the label column specified is in the output of the SQL
-    if label_col and not label_col in valid_df.keys():
+    if label_col and not label_col.upper() in valid_df.keys():
         raise SpliceMachineException(status_code=status.HTTP_400_BAD_REQUEST, code=ExceptionCodes.INVALID_SQL,
                                         message=f"Provided label column {label_col} is not available in the provided SQL")
+
+    # Ensure the primary key columns are in the output of the SQL
+    pks = set(key.upper() for key in pk_cols)
+    missing_keys = pks - set(valid_df.keys())
+    if missing_keys:
+        raise SpliceMachineException(status_code=status.HTTP_400_BAD_REQUEST, code=ExceptionCodes.INVALID_SQL,
+                                        message=f"Provided primary key(s) {missing_keys} are not available in the provided SQL")
+
     # Confirm that all join_keys provided correspond to primary keys of created feature sets
-    pks = set(i[0].upper() for i in db.query(distinct(models.FeatureSetKey.key_column_name)).all())
-    missing_keys = set(i.upper() for i in join_keys) - pks
+    jks = set(i[0].upper() for i in db.query(distinct(models.FeatureSetKey.key_column_name)).all())
+    missing_keys = set(i.upper() for i in join_keys) - jks
     if missing_keys:
         raise SpliceMachineException(status_code=status.HTTP_400_BAD_REQUEST, code=ExceptionCodes.DOES_NOT_EXIST,
                                 message=f"Not all provided join keys exist. Remove {missing_keys} or " \

--- a/feature_store/src/rest_api/routers/synchronous.py
+++ b/feature_store/src/rest_api/routers/synchronous.py
@@ -260,7 +260,7 @@ def create_training_view(tv: schemas.TrainingViewCreate, db: Session = Depends(c
             status_code=status.HTTP_400_BAD_REQUEST, code=ExceptionCodes.BAD_ARGUMENTS,
             message="Name of training view cannot be None!")
 
-    crud.validate_training_view(db, tv.name, tv.sql_text, tv.join_columns, tv.label_column)
+    crud.validate_training_view(db, tv.name, tv.sql_text, tv.join_columns, tv.pk_columns, tv.label_column)
     crud.create_training_view(db, tv)
 
 @SYNC_ROUTER.post('/deploy-feature-set', status_code=status.HTTP_200_OK, response_model=schemas.FeatureSet,


### PR DESCRIPTION
## Description
Validate the existence of provided primary keys during the creation of a training view

## Motivation and Context
We need to validate that the primary keys attached to a training view exist within that view
Fixes [DBAAS-5172](https://splicemachine.atlassian.net/browse/DBAAS-5172)

## Dependencies
N/A

## How Has This Been Tested?
Tested against standalone db
