### PR TITLE
fix: mlflow has a cross origin error when embedded in an iframe. 

### DIFF
--- a/mlflow/src/scripts/entrypoint.sh
+++ b/mlflow/src/scripts/entrypoint.sh
@@ -91,6 +91,10 @@ then
     export MODE="development"
 fi
 
+# Fix for the UI code being enbedded in an iframe
+# Replace window.parent.location.origin with *
+sed -i 's/window\.parent\.location\.origin)/"*")/' /usr/local/lib/python3.6/site-packages/mlflow/server/js/build/static/js/main.cc1b77ea.chunk.js
+
 
 echo "Starting Job Tracking UI on port :${GUI_PORT}"
 nohup gunicorn --bind 0.0.0.0:${GUI_PORT} --chdir ${SRC_HOME}/app --workers ${GUNICORN_THREADS} main:APP &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a cross origin error when embedding mlflow ui in the new cloud manager ui. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to embed mlflow into the initial version of the new cloud manager and it is giving a cross origin error.  The ML Flow UI will be going away soon so implemented a temporary solution until then.  This issue was previously reported in the mlflow repo - https://github.com/mlflow/mlflow/issues/3583.   See https://splicemachine.atlassian.net/browse/DBAAS-5255 for more details.

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->
N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the test you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed to a test environment

## Screenshots (if appropriate):
N/A