### PR TITLE
fix for docs showing up behind a proxy

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,6 +60,7 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:-admin}
       FRAMEWORK_NAME: my-framework
       MODE: development
+      ROOT_PATH: / # Change this to /featurestore in the cloud
       ENVIRONMENT: ${ENVIRONMENT:-default}
       AIRFLOW_URL: "http://host.docker.internal:8081/api/v1"
       AIRFLOW_USER: airflow

--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -832,7 +832,7 @@ def validate_training_view(db: Session, name, sql_text, join_keys, pk_cols, labe
     # Lazily evaluate sql resultset, ensure that the result contains all columns matching pks, join_keys, tscol and label_col
     from sqlalchemy.exc import ProgrammingError
     try:
-        valid_df = db.execute(sql_text).first()
+        valid_df = db.execute(sql_text)
     except ProgrammingError as e:
         if '[Splice Machine][Splice]' in str(e):
             raise SpliceMachineException(status_code=status.HTTP_400_BAD_REQUEST, code=ExceptionCodes.INVALID_SQL,

--- a/feature_store/src/rest_api/main.py
+++ b/feature_store/src/rest_api/main.py
@@ -15,6 +15,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 APP: FastAPI = FastAPI(
     title="Feature Store API",
+    root_path=env_vars.get('ROOT_PATH','/'), # Because we run behind a proxy in the cloud, it will be /featurestore
     debug=env_vars.get('DEBUG', False),
     description="API for asynchronous and synchronous calls to the feature store"
 )


### PR DESCRIPTION
This enables us to make the interactive swaggerhub docs available from a database environment. Every database that stands up with mlmanager will have docs available at DB_URL/featurestore/docs 

Like so: https://test-nonprod-gke-dev1.gke.splicemachine-dev.io/featurestore/docs

## Description
Enable a `root_path` to be set for use with a proxy (cloud)

## Motivation and Context
Great for application developers (mentalstack ex)

## Dependencies
Env must be set in [dbaas](https://github.com/splicemachine/dbaas-infrastructure/pull/1612)

## How Has This Been Tested?
 https://test-nonprod-gke-dev1.gke.splicemachine-dev.io/featurestore/docs

## Screenshots (if appropriate):
N/A