### PR TITLE
DBAAS-5189: get_feature_vector needs to return the primary keys along with the vector

### DIFF
--- a/feature_store/src/rest_api/routers/synchronous.py
+++ b/feature_store/src/rest_api/routers/synchronous.py
@@ -81,7 +81,7 @@ def get_features_by_name(names: List[str] = Query([], alias="name"), db: Session
                 description="Gets a feature vector given a list of Features and primary key values for their corresponding Feature Sets", 
                 operation_id='get_feature_vector', tags=['Features'])
 @managed_transaction
-def get_feature_vector(fjk: schemas.FeatureJoinKeys, sql: bool = False, db: Session = Depends(crud.get_db)):
+def get_feature_vector(fjk: schemas.FeatureJoinKeys, pks: bool = True, sql: bool = False, db: Session = Depends(crud.get_db)):
     """
     Gets a feature vector given a list of Features and primary key values for their corresponding Feature Sets
     """
@@ -93,7 +93,7 @@ def get_feature_vector(fjk: schemas.FeatureJoinKeys, sql: bool = False, db: Sess
     feature_sets = crud.get_feature_sets(db, [f.feature_set_id for f in feats])
     crud.validate_feature_vector_keys(join_keys, feature_sets)
 
-    return crud.get_feature_vector(db, feats, join_keys, feature_sets, sql)
+    return crud.get_feature_vector(db, feats, join_keys, feature_sets, pks, sql)
 
 
 @SYNC_ROUTER.post('/feature-vector-sql', status_code=status.HTTP_200_OK, response_model=str,


### PR DESCRIPTION
## Description
An optional parameter was added that returns the primary keys with the vector (default true)
docstrings of the function have been updated to reflect the change

## Motivation and Context
Feature vectors need to return the primary keys of the associated feature sets
fixes [DBAAS-5198](https://splicemachine.atlassian.net/browse/DBAAS-5189)

## Dependencies
N/A

## How Has This Been Tested?
tested against standalone

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/26292901/113358439-cbee8400-9313-11eb-87fc-a8c517b08582.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
New parameter to get_feature_vector()

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
