### PR TITLE
missing featurestore schema prefix on function name

### DIFF
--- a/feature_store/src/rest_api/utils/pipeline_utils/pipeline_utils.py
+++ b/feature_store/src/rest_api/utils/pipeline_utils/pipeline_utils.py
@@ -121,7 +121,7 @@ def generate_backfill_sql(schema: str, table: str, source: schemas.Source, featu
     # Get the SQL integer value of the smallest window and it's length (see function description)
     min_window_length, min_window_value = helpers.get_min_window_sql(all_windows)
 
-    innersource_list += f", TimestampSnapToInterval(timestamp({source.event_ts_column}), {min_window_value},{min_window_length}) {source.event_ts_column}"
+    innersource_list += f", FeatureStore.TimestampSnapToInterval(timestamp({source.event_ts_column}), {min_window_value},{min_window_length}) {source.event_ts_column}"
 
 
     pk_col_list = ",".join(source.pk_columns)
@@ -182,7 +182,7 @@ def generate_pipeline_sql(db,  source: schemas.Source, pipeline: schemas.Pipelin
     extract_scope_sql = f'''
         SELECT 
             DISTINCT {pk_col_list}, 
-            TimestampSnapToInterval(timestamp({source.event_ts_column}), {window_value}, {window_length}) asof_ts 
+            FeatureStore.TimestampSnapToInterval(timestamp({source.event_ts_column}), {window_value}, {window_length}) asof_ts 
         FROM ({source.sql_text}) isrc 
         WHERE isrc.{source.update_ts_column} > timestamp('{ts_limit}')
     '''


### PR DESCRIPTION

## Description
The new function created, TimestampSnapToInterval, was created in the featurestore schema, but this didn't prefix that. This fixes the issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the test you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
