### PR TITLE
fix for VTI mdoel deployment executed via OLAP engine

### DIFF
--- a/mlrunner/pom.xml
+++ b/mlrunner/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.splicemachine</groupId>
     <artifactId>mlrunner</artifactId>
-    <version>0.1.8</version>
+    <version>0.1.9</version>
     <properties>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.12</scala.version>

--- a/mlrunner/src/main/java/com/splicemachine/mlrunner/AbstractRunner.java
+++ b/mlrunner/src/main/java/com/splicemachine/mlrunner/AbstractRunner.java
@@ -40,7 +40,8 @@ public abstract class AbstractRunner implements Externalizable {
         Object [] obj = null;
         java.sql.ResultSet rs = pstmt.executeQuery();
         if (rs.next()) {
-            final Blob blobModel = rs.getBlob(1);
+            final Blob bm = rs.getBlob(1);
+            final byte[] blobModel = bm.getBytes(1,(int)bm.length());
             final String library = rs.getString(2);
             obj = new Object[]{blobModel, library};
         }

--- a/mlrunner/src/main/java/com/splicemachine/mlrunner/H2ORunner.java
+++ b/mlrunner/src/main/java/com/splicemachine/mlrunner/H2ORunner.java
@@ -28,9 +28,9 @@ public class H2ORunner extends AbstractRunner implements Externalizable {
 
     public H2ORunner(){};
 
-    public H2ORunner(final Blob modelBlob) throws SQLException, IOException, ClassNotFoundException {
+    public H2ORunner(final byte[] modelBlob) throws SQLException, IOException, ClassNotFoundException {
         this.deserModel = new SQLBlob(modelBlob);
-        final InputStream bis = modelBlob.getBinaryStream();
+        final InputStream bis = new ByteArrayInputStream(modelBlob);
         final ObjectInputStream ois = new ObjectInputStream(bis);
         this.model = (EasyPredictModelWrapper) ois.readObject();
     }

--- a/mlrunner/src/main/java/com/splicemachine/mlrunner/KerasRunner.java
+++ b/mlrunner/src/main/java/com/splicemachine/mlrunner/KerasRunner.java
@@ -32,9 +32,9 @@ public class KerasRunner extends AbstractRunner implements Externalizable {
     SQLBlob deserModel;
 
     public KerasRunner(){};
-    public KerasRunner(Blob modelBlob) throws SQLException, UnsupportedKerasConfigurationException, IOException, InvalidKerasConfigurationException {
+    public KerasRunner(byte[] modelBlob) throws SQLException, UnsupportedKerasConfigurationException, IOException, InvalidKerasConfigurationException {
         this.deserModel = new SQLBlob(modelBlob);
-        InputStream is = modelBlob.getBinaryStream();
+        InputStream is =new ByteArrayInputStream(modelBlob);
         this.model = KerasModelImport.importKerasSequentialModelAndWeights(is, true);
     }
 

--- a/mlrunner/src/main/java/com/splicemachine/mlrunner/MLRunner.java
+++ b/mlrunner/src/main/java/com/splicemachine/mlrunner/MLRunner.java
@@ -73,7 +73,7 @@ public class MLRunner implements DatasetProvider, VTICosting {
             // Get the model blob and the library
             final Object[] modelAndLibrary = AbstractRunner.getModelBlob(modelID);
             final String lib = ((String) modelAndLibrary[1]).toLowerCase();
-            Blob model = (Blob) modelAndLibrary[0];
+            byte[] model = (byte[]) modelAndLibrary[0];
             switch (lib) {
                 case "h2o":
                     runner = new H2ORunner(model);

--- a/mlrunner/src/main/java/com/splicemachine/mlrunner/MLeapRunner.java
+++ b/mlrunner/src/main/java/com/splicemachine/mlrunner/MLeapRunner.java
@@ -38,9 +38,9 @@ public class MLeapRunner extends AbstractRunner implements Externalizable {
     private static final Logger LOG = Logger.get(MLRunner.class);
 
     public MLeapRunner(){};
-    public MLeapRunner(final Blob modelBlob) throws IOException, ClassNotFoundException, SQLException {
+    public MLeapRunner(final byte[] modelBlob) throws IOException, ClassNotFoundException, SQLException {
         this.deserModel = new SQLBlob(modelBlob);
-        final InputStream bis = modelBlob.getBinaryStream();
+        final InputStream bis = new ByteArrayInputStream(modelBlob);
         final ObjectInputStream ois = new ObjectInputStream(bis);
         this.model = (Transformer) ois.readObject();
     }

--- a/mlrunner/src/main/java/com/splicemachine/mlrunner/SKRunner.java
+++ b/mlrunner/src/main/java/com/splicemachine/mlrunner/SKRunner.java
@@ -26,13 +26,11 @@ public class SKRunner extends AbstractRunner implements Externalizable {
     private static final Logger LOG = Logger.get(MLRunner.class);
 
     public SKRunner(){};
-    public SKRunner(final Blob modelBlob) throws SQLException, IOException {
+    public SKRunner(final byte[] modelBlob) throws SQLException, IOException {
+
+
         this.deserModel = new SQLBlob(modelBlob);
-        InputStream is = modelBlob.getBinaryStream();
-        int fileSize = (int)modelBlob.length();
-        final byte[] allBytes = new byte[fileSize];
-        is.read(allBytes);
-        this.model = allocateDirect(fileSize).put(allBytes);
+        this.model = allocateDirect(modelBlob.length).put(modelBlob);
     }
 
     private Object[][] parseData(LinkedList<ExecRow> unprocessedRows, List<Integer> modelFeaturesIndexes) throws StandardException {


### PR DESCRIPTION
Serializing the Blob object was causing intermittent problems when queries executed via OLAP. Using the raw bytes instead of the Blob fixed the issue. 

## Description
Switched from serializing a Blob to serializing a byte[]

## Motivation and Context
Model execution may go through spark at the will of the optimizer, so it needs to function properly

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
See below

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/114249353-5cf2da00-9968-11eb-9e9b-c5b81585017a.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
