### PR TITLE
DBAAS-5399 - better warnings for jobs 

### DIFF
--- a/bobby/src/handlers/run_handlers/database_deployment_handler.py
+++ b/bobby/src/handlers/run_handlers/database_deployment_handler.py
@@ -211,7 +211,7 @@ class DatabaseDeploymentHandler(BaseDeploymentHandler):
         ddl_creator.create()
         self.logger.info("Flushing", send_db=True)
         self.Session.flush()
-        self.logger.warning("Committing Transaction to Database", send_db=True)
+        self.logger.info("Committing Transaction to Database", send_db=True)
         self.savepoint.commit() # Release the savepoint so we can commit transactions
         self.Session.commit()
         self.logger.info("Committed.", send_db=True)


### PR DESCRIPTION
This repo didn't need any changes, except that we were warning about a database transaction commit when we really didn't need to. Since we are now notifying about warnings, we should fix that.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the test you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
