### PR TITLE
DBAAS-5476: feature validation

### DIFF
--- a/feature_store/src/rest_api/utils/pipeline_utils/pipeline_utils.py
+++ b/feature_store/src/rest_api/utils/pipeline_utils/pipeline_utils.py
@@ -59,10 +59,13 @@ def create_pipeline_entities(db: Session, sf: schemas.SourceFeatureSetAgg, sourc
         # Create the features that the aggregations produce
         for f in agg.agg_functions:
             for w in agg.agg_windows: # For each agg function, there are n windows that make n features
+                # Validate that the feature name is valid (in case they provided an already used prefix)
+                fname = helpers.build_agg_feature_name(feat_prefix,f,w)
+                crud.validate_feature(db, fname, sql_to_datatype('DOUBLE'))
                 agg_features.append(
                     schemas.FeatureCreate(
                         feature_set_id=fset_id,
-                        name=helpers.build_agg_feature_name(feat_prefix,f,w),
+                        name=fname,
                         description=f'{f} of {agg.column_name} over last {w}',
                         feature_data_type=sql_to_datatype('DOUBLE'),
                         feature_type='C',  # 'C'ontinuous


### PR DESCRIPTION
Feature validation on agg feature set

## Description
We weren't validation feature names on aggregation feature sets. This adds that

## Motivation and Context
Throwing 500 errors on duplicate feature names.

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
Ran the following
```
from splicemachine.features.pipelines import FeatureAggregation, FeatureAgg, AggWindow
from splicemachine.features import FeatureStore
from splicemachine.features import FeatureType
fs = FeatureStore()
fs.login_fs('splice','admin')
fs.set_feature_store_url('http://localhost:8000')
source_name = 'CUSTOMER_RFM'
try:
  fs.remove_source(source_name)
except:
  pass
fs.create_source(
    name=source_name,
    sql='''SELECT * FROM RETAIL_RFM.CUSTOMER_CATEGORY_ACTIVITY''',
    event_ts_column='INVOICEDATE',
    update_ts_column='INVOICEDATE',
    primary_keys=['CUSTOMERID']
)
from datetime import datetime
start_time = datetime.today()
schedule_interval = AggWindow.get_window(5,AggWindow.DAY)
backfill_start = datetime.strptime('2002-01-01 00:00:00', '%Y-%m-%d %H:%M:%S')
backfill_interval = schedule_interval
if fs.feature_set_exists('RETAIL_FS','AUTO_RFM'):
  fs.remove_feature_set('RETAIL_FS','AUTO_RFM')
fs.create_aggregation_feature_set_from_source(
    source_name, 'RETAIL_FS', 'AUTO_RFM', start_time=start_time,
    schedule_interval=schedule_interval, backfill_start_time=backfill_start,
    backfill_interval=backfill_interval,
    aggregations = [
        FeatureAggregation(feature_name_prefix = 'AR_CLOTHING_QTY', column_name = 'CLOTHING_QTY',         agg_functions=['sum','max'],   agg_windows=['1d','2d','90d'], agg_default_value = 0.0 ),
        FeatureAggregation(feature_name_prefix = 'AR_DELICATESSEN_QTY', column_name = 'DELICATESSEN_QTY', agg_functions=['avg'], agg_windows=['1d','2d', '2w'], agg_default_value = 11.5 ),
        FeatureAggregation(feature_name_prefix = 'AR_GARDEN_QTY' ,      column_name = 'GARDEN_QTY',       agg_functions=['count','avg'], agg_windows=['30d','90d', '1q'], agg_default_value = 8 )
    ]
)
```

Then ran again with a new feature set name but same features and got
```
SpliceMachineException: Cannot add feature AR_CLOTHING_QTY_sum_1d, feature already exists in Feature Store. Try a new feature name.
```


### Fixes
Agg feature set better feature validation

