### PR TITLE
DBAAS-5475: direct PK validation for db deploy

### DIFF
--- a/bobby/src/handlers/run_handlers/db_deploy_utils/db_model_ddl.py
+++ b/bobby/src/handlers/run_handlers/db_deploy_utils/db_model_ddl.py
@@ -156,9 +156,11 @@ class DatabaseModelDDL:
                 {schema_str}"""
 
         pk_cols = ''
+
+        table_columns = [i.lower() for i in list(self.model.get_metadata(Metadata.SQL_SCHEMA).keys())]
         for key in self.primary_key:
             # If pk is already in the schema_string, don't add another column. PK may be an existing value
-            if key.lower() not in schema_str.lower() and \
+            if key.lower() not in table_columns and \
                     key.upper() not in self.model.get_metadata(Metadata.RESERVED_COLUMNS):
                 table_create_sql += f'{key} {self.primary_key[key]},'
             pk_cols += f'{key},'


### PR DESCRIPTION
We weren't validating primary key columns well, and there ended up being conflicts depending on column names of the deploy table and the name of the primary key column. This directly compares the primary key column to existing database table columns

## Description


## Motivation and Context
Bug



## How Has This Been Tested?
Deployed on sales cluster and fixed error

## Screenshots (if appropriate):

## Changelog Inclusions

### Fixes
Better primary key validation for deploy database
