### PR TITLE
include deploy timestamp on fset return after deploy

### DIFF
--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -1181,9 +1181,12 @@ def deploy_feature_set(db: Session, fset: schemas.FeatureSet) -> schemas.Feature
     # db.query(models.FeatureSet).filter(models.FeatureSet.feature_set_id==fset.feature_set_id).\
     #     update({models.FeatureSet.deployed: True, models.FeatureSet.deploy_ts: datetime.now()})
     updt = update(models.FeatureSet).where(models.FeatureSet.feature_set_id == fset.feature_set_id). \
-        values(deployed=True, deploy_ts=text('CURRENT_TIMESTAMP'))
+        values(deployed=True, deploy_ts=text('CURRENT_TIMESTAMP'), last_update_ts=text('CURRENT_TIMESTAMP'))
     stmt = updt.compile(dialect=db.get_bind().dialect, compile_kwargs={"literal_binds": True})
     db.execute(str(stmt))
+    fset.deploy_ts = db.query(models.FeatureSet.deploy_ts).\
+        filter(models.FeatureSet.feature_set_id == fset.feature_set_id).\
+        first()[0]
     fset.deployed = True
     logger.info('Done.')
     return fset


### PR DESCRIPTION
We weren't including the deploy timestamp on the returned object after we deploy a feature set

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the test you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
