### PR TITLE
DBAAS:5574 - include training set and deployment dependencies in feature-set-details

### DIFF
--- a/feature_store/src/rest_api/routers/synchronous.py
+++ b/feature_store/src/rest_api/routers/synchronous.py
@@ -438,6 +438,9 @@ def get_feature_set_details(schema: Optional[str] = None, table: Optional[str] =
         if not fsets:
             raise SpliceMachineException(status_code=status.HTTP_404_NOT_FOUND ,code=ExceptionCodes.DOES_NOT_EXIST,
                                      message=f'The feature set {schema}.{table} Does not exist.')
+        deps = crud.get_feature_set_dependencies(db, fsets[0].feature_set_id)
+        fsets[0].has_training_sets = bool(deps.get('training_set'))
+        fsets[0].has_deployments = bool(deps.get('model'))
     else:
         fsets = crud.get_feature_sets(db)
 

--- a/feature_store/src/rest_api/schemas.py
+++ b/feature_store/src/rest_api/schemas.py
@@ -110,6 +110,8 @@ class FeatureSet(FeatureSetBase):
 class FeatureSetDetail(FeatureSet):
     features: Optional[List[Feature]] = None
     num_features: Optional[int] = None
+    has_training_sets: Optional[bool] = None
+    has_deployments: Optional[bool] = None
 
 class TrainingViewBase(BaseModel):
     name: Optional[str] = None

--- a/feature_store/src/rest_api/utils/feature_utils.py
+++ b/feature_store/src/rest_api/utils/feature_utils.py
@@ -18,11 +18,11 @@ def _deploy_feature_set(schema: str, table: str, db: Session):
     The feature set must have already been created with :py:meth:`~features.FeatureStore.create_feature_set`
     """
     try:
-        fset = crud.get_feature_sets(db, _filter={'schema_name': schema, 'table_name': table})[0]
+        fset = crud.get_feature_sets(db, feature_set_names=[f'{schema}.{table}'])[0]
     except:
         raise SpliceMachineException(
             status_code=status.HTTP_404_NOT_FOUND, code=ExceptionCodes.DOES_NOT_EXIST,
-            message=f"Cannot find feature set {schema}.{table}. Ensure you've created this"
+            message=f"Cannot find feature set {schema}.{table}. Ensure you've created this "
             f"feature set using fs.create_feature_set before deploying.")
     if fset.deployed:
         raise SpliceMachineException(


### PR DESCRIPTION
Include in the feature-set-details route whether the feature set has training set or deployment dependencies


## Motivation and Context
UI Team request



## How Has This Been Tested?
Hitting the route 

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/118056707-6650d700-b358-11eb-81ec-0b9ec944d57c.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
