### PR TITLE
DBAAS-5518: live model status route

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,9 +15,10 @@ services:
     image: splicemachine/ml-workflow_jupyter:0.0.3
   mlflow:
     environment:
-      DB_HOST: host.docker.internal
+      DB_HOST: ${DB_HOST:-host.docker.internal}
       DB_USER: mlmanager
       DB_PASSWORD: ${DB_PASSWORD:-admin}
+      DB_DATABASE_NAME: ${DB_DATABASE_NAME:-splicedb}
       FRAMEWORK_NAME: my-framework
       MODE: development
       ENVIRONMENT: ${ENVIRONMENT:-default}

--- a/mlflow/src/app/main.py
+++ b/mlflow/src/app/main.py
@@ -25,7 +25,7 @@ from shared.logger.logging_config import logger
 from shared.models.splice_models import Handler, Job
 from shared.models.mlflow_models import SqlArtifact
 from shared.services.authentication import Authentication, User
-from shared.services.database import SQLAlchemyClient
+from shared.services.database import SQLAlchemyClient, DatabaseSQL
 from shared.services.handlers import HandlerNames, KnownHandlers
 
 __author__: str = "Splice Machine, Inc."
@@ -206,6 +206,23 @@ def watch_job(task_id: int) -> Response:
     :return: (Response) HTML
     """
     return show_html('watch_logs.html', task_id=task_id)
+
+@APP.route('/api/rest/deployments', methods=['GET'])
+@Authentication.basic_auth_required
+@HTTP.generate_json_response
+def get_deployments():
+    """
+    Gets all model deployments and their current status
+    """
+    res = Session.execute(DatabaseSQL.get_deployment_status)
+    cols = [i[0] for i in res.cursor.description]
+    rows = res.fetchall()
+    data = [(col,[row[i] for row in rows]) for i,col in enumerate(cols)]
+    return create_json(data)
+
+
+
+
 
 ########################################################################################################
 #                               Splice Machine Artifact Store                                          #

--- a/shared/shared/services/database.py
+++ b/shared/shared/services/database.py
@@ -179,6 +179,8 @@ class DatabaseSQL:
     live_status_view_selector: str = \
         """
        SELECT mm.run_uuid,
+           ssa.schemaname as SCHEMA_NAME,
+           sta.tablename TABLE_NAME,
            mm.action,
            CASE
                WHEN (
@@ -186,16 +188,20 @@ class DatabaseSQL:
                      AND mm.action = 'DEPLOYED') THEN 'Table or Trigger Missing'
                ELSE mm.action
            END AS deployment_status,
-           mm.tableid,
-           mm.trigger_type,
-           mm.triggerid,
            mm.db_env,
            mm.db_user,
-           mm.action_date
-    FROM DATABASE_DEPLOYED_METADATA mm
+           mm.action_date,
+           ssa.schemaid,
+           mm.tableid,
+           mm.triggerid,
+           mm.trigger_type
+    FROM mlmanager.DATABASE_DEPLOYED_METADATA mm
     LEFT OUTER JOIN sys.systables sta USING (tableid)
+    LEFT OUTER JOIN sys.sysschemas ssa USING (schemaid)
     LEFT OUTER JOIN sys.systriggers st ON (mm.triggerid = st.triggerid)
         """
+
+    get_deployment_status: str = 'SELECT * from MLMANAGER.LIVE_MODEL_STATUS'
 
     retrieve_jobs: str = \
         """


### PR DESCRIPTION
Server side route to get live model status

## Description
Helpful route to see which models are deployed and the status of their deployment (does the table still exist? Does the trigger?)

## Motivation and Context
Helpful for users to know what models are deployed
Adds authentication to the route since it is server side now

## Dependencies
None

## How Has This Been Tested?
![image](https://user-images.githubusercontent.com/22605641/118181587-ec772700-b405-11eb-9f88-e017cbf8c007.png)

## Screenshots (if appropriate):

## Changelog Inclusions


### Additions
server side get_deployed_models function 

