### PR TITLE
fix for logic of returning single training view/featureset

### DIFF
--- a/feature_store/src/rest_api/routers/synchronous.py
+++ b/feature_store/src/rest_api/routers/synchronous.py
@@ -445,7 +445,7 @@ def get_feature_set_details(schema: Optional[str] = None, table: Optional[str] =
     # Will get an error that we are trying to set 2 different values of features for FeatureSetDetail
     fsets = [schemas.FeatureSetDetail(**fset.__dict__, features=fset.__dict__.pop('features') or crud.get_features(db, fset)) for fset in fsets]
 
-    return fsets if len(fsets) > 1 else fsets[0]
+    return fsets if len(fsets) != 1 else fsets[0]
 
 @SYNC_ROUTER.get('/training-view-details', status_code=status.HTTP_200_OK,
                  response_model=Union[List[schemas.TrainingViewDetail],schemas.TrainingViewDetail],
@@ -474,7 +474,7 @@ def get_training_view_details(name: Optional[str] = None, db: Session = Depends(
         fds = list(map(lambda f, feat_sets=feat_sets: schemas.FeatureDetail(**f.__dict__, feature_set_name=feat_sets[f.feature_set_id]), feats))
         descs.append(schemas.TrainingViewDetail(**tvw.__dict__, features=fds))
 
-    return descs if len(descs) > 1 else descs[0]
+    return descs if len(descs) != 1 else descs[0]
 
 @SYNC_ROUTER.put('/features', status_code=status.HTTP_200_OK, response_model=schemas.Feature,
                  description="Updates a feature's metadata (description, tags, attributes)",


### PR DESCRIPTION
UI Team wants a single object returned if only one entity is available. My logic didn't manage what to do if no elements are available (empty feature store). This fixes that (not indexing into an empty list now)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the test you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
