### PR TITLE
[PATCH] for featurestore 2.8.0 release - feature detail and feature set detail

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       AIRFLOW_URL: "http://host.docker.internal:9876/api/v1"
       AIRFLOW_USER: airflow
       AIRFLOW_PASSWORD: airflow
-    image: splicemachine/sm_k8_feature_store:0.0.5
+    image: splicemachine/sm_k8_feature_store:0.0.5_patch1
     ports:
       - "8000:8000"
     build:

--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -1701,8 +1701,16 @@ def get_deployments(db: Session, _filter: Dict[str, str] = None, feature: schema
             filter(tsf.feature_id.in_(p))
 
     deployments = []
-    for name, deployment in q.all():
-        deployments.append(schemas.DeploymentDetail(**deployment.__dict__, training_set_name=name))
+    for name, deployment, tset_start, tset_end, tset_create in q.all():
+        deployments.append(
+            schemas.DeploymentDetail(
+                **deployment.__dict__,
+                training_set_name=name,
+                training_set_start_ts=tset_start,
+                training_set_end_ts=tset_end,
+                training_set_create_ts=tset_create
+            )
+        )
     return deployments
 
 


### PR DESCRIPTION
A bug was introduced because of training set versions in the feature detail and feature set detail.


**NOTE:** I am going to bump the feature_store pod version for now, and leave it as a patch tag. If we find more bugs, we can increase this patch (so dev environments can work), and at the end of the week we will create a new release and increase feature_store to 0.0.6. 

## Description
Training set versions now have extra fields, `training_set_start_ts` `training_set_end_ts` and `training_set_create_ts` which the query in crud didn't expect. This fixes that 

## Motivation and Context
Feature detail and feature set detail routes were breaking when associated deployments existed.

## Dependencies
None

## How Has This Been Tested?
sales-gke-dev4 cluster.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/22605641/119399013-5adda400-bca6-11eb-89fa-6494b7115334.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes
* feature detail
* feature set detail
### Deprecated

### Removed

### Breaking Changes
