### PR TITLE
feature store patch2 - feature statistics dependency

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       AIRFLOW_URL: "http://host.docker.internal:9876/api/v1"
       AIRFLOW_USER: airflow
       AIRFLOW_PASSWORD: airflow
-    image: splicemachine/sm_k8_feature_store:0.0.5_patch1
+    image: splicemachine/sm_k8_feature_store:0.0.5_patch2
     ports:
       - "8000:8000"
     build:

--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -265,6 +265,10 @@ def delete_features_from_feature_set(db: Session, feature_set_id: int):
     :param db: Database Session
     :param features: feature IDs to delete
     """
+    # Delete feature stats
+    logger.info("Removing feature stats")
+    p = db.query(models.Feature.feature_id).filter(models.Feature.feature_set_id==feature_set_id).subquery('p')
+    db.query(models.FeatureStats).filter(models.FeatureStats.feature_id.in_(p)).delete(synchronize_session='fetch')
     # Delete features
     logger.info("Removing features")
     db.query(models.Feature).filter(models.Feature.feature_set_id == feature_set_id).delete(synchronize_session='fetch')


### PR DESCRIPTION

## Description
We added feature statistics in the new release but we don't delete those rows when a feature set is deleted. This fixes that

## Motivation and Context
Bug patch

## Dependencies
None

## How Has This Been Tested?
sales cluster

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes
* Deleting a feature set

### Deprecated

### Removed

### Breaking Changes
