### PR TITLE
Feature Store Patch 4: retrieve_training_set_metadata_from_deployment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       AIRFLOW_URL: "http://host.docker.internal:9876/api/v1"
       AIRFLOW_USER: airflow
       AIRFLOW_PASSWORD: airflow
-    image: splicemachine/sm_k8_feature_store:0.0.5_patch3
+    image: splicemachine/sm_k8_feature_store:0.0.5_patch4
     ports:
       - "8000:8000"
     build:

--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -1654,7 +1654,7 @@ def retrieve_training_set_metadata_from_deployment(db: Session, schema_name: str
     ). \
         select_from(d). \
         join(ts, d.training_set_id == ts.training_set_id). \
-        join(tsi, d.training_set_version == tsi.training_set_version and tsi.training_set_id == d.training_set_id). \
+        join(tsi, (d.training_set_version == tsi.training_set_version) & (tsi.training_set_id == d.training_set_id)). \
         join(tsf, tsf.training_set_id == d.training_set_id). \
         outerjoin(tv, tv.view_id == ts.view_id). \
         join(f, tsf.feature_id == f.feature_id). \


### PR DESCRIPTION
## Description
Fixed bug in `retrieve_training_set_metadata_from_deployment`

## Motivation and Context
Calls to `retrieve_training_set_metadata_from_deployment` were returning lists of duplicate features

## Dependencies
N/A

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):

## Changelog Inclusions

### Additions

### Changes

### Fixes
`retrieve_training_set_metadata_from_deployment`

### Deprecated

### Removed

### Breaking Changes
