### PR TITLE
add view parameter to list training sets

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       AIRFLOW_URL: "http://host.docker.internal:9876/api/v1"
       AIRFLOW_USER: airflow
       AIRFLOW_PASSWORD: airflow
-    image: splicemachine/sm_k8_feature_store:0.0.5_patch4
+    image: splicemachine/sm_k8_feature_store:0.0.5_patch5
     ports:
       - "8000:8000"
     build:

--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -541,9 +541,10 @@ def get_training_set_instance_by_name(db: Session, name: str, version: int = Non
         first()
     return schemas.TrainingSetMetadata(**tsm._asdict()) if tsm else None
 
-def list_training_sets(db: Session) -> List[schemas.TrainingSetMetadata]:
+def list_training_sets(db: Session, tvw_id: int = None) -> List[schemas.TrainingSetMetadata]:
     """
     Gets a list of training sets (Name, View ID, Training Set ID, Last_update_ts, Last_update_username, label)
+    :param tvw_id: A training view ID. If provided, will return only training sets created from that view
 
     :return: List of Training Set Metadata (Name, View ID, Training Set ID, Last_update_ts, Last_update_username, label)
     """
@@ -565,6 +566,8 @@ def list_training_sets(db: Session) -> List[schemas.TrainingSetMetadata]:
         join(tsf, and_(ts.training_set_id==tsf.training_set_id,tsf.is_label==True),isouter=True).\
         join(f, f.feature_id==tsf.feature_id, isouter=True).\
         join(tv, ts.view_id==tv.view_id, isouter=True)
+    if tvw_id:
+        q = q.filter(ts.view_id==tvw_id)
 
     tsms: List[schemas.TrainingSetMetadata] = []
     for name, tsid, view_id, user, ts, label in q.all():

--- a/feature_store/src/rest_api/routers/synchronous.py
+++ b/feature_store/src/rest_api/routers/synchronous.py
@@ -300,12 +300,14 @@ Returns information about all Training Sets:
 * Last Update TS
 * Last Update Username
 * label column (if one exists)
+
+If a Training View is provided (optional) it will return only training sets created from that Training View
 """
 @SYNC_ROUTER.get('/training-sets', status_code=status.HTTP_200_OK, response_model=List[schemas.TrainingSetMetadata],
                 description=list_ts_desc,
                 operation_id='list_training_sets', tags=['Training Sets'])
 @managed_transaction
-def list_training_sets(db: Session = Depends(crud.get_db)):
+def list_training_sets(training_view: str = None, db: Session = Depends(crud.get_db)):
     """
     Returns information about all Training Sets:
     * Name
@@ -315,7 +317,10 @@ def list_training_sets(db: Session = Depends(crud.get_db)):
     * Last Update Username
     * label column (if one exists)
     """
-    return crud.list_training_sets(db)
+    view_id = None
+    if training_view:
+        view_id = crud.get_training_view_id(db, training_view)
+    return crud.list_training_sets(db, tvw_id=view_id)
 
 @SYNC_ROUTER.get('/training-set-details', status_code=status.HTTP_200_OK, response_model=schemas.TrainingSet,
                 description='Returns details about a particular training set instance given a name and version. '


### PR DESCRIPTION
Enable users to filter training sets by a view

## Description
Optional training_view parameter to the GET /training-sets route to filter training sets

## Motivation and Context
For the UI

## Dependencies
None

## How Has This Been Tested?
Against K8s

## Screenshots (if appropriate):
With a view param:
![image](https://user-images.githubusercontent.com/22605641/119831385-3a426380-becb-11eb-9604-5c3b9335ed23.png)


Without a view param
![image](https://user-images.githubusercontent.com/22605641/119831878-b177f780-becb-11eb-9704-539cb7ed51af.png)


With a view that does not exist
![image](https://user-images.githubusercontent.com/22605641/119831835-a6bd6280-becb-11eb-9f56-bc0b4af9d245.png)

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions
- Optional training_view parameter to the GET /training-sets route to filter training sets
