### PR TITLE
handle default environments for bobby

### DIFF
--- a/bobby/src/scripts/entrypoint.sh
+++ b/bobby/src/scripts/entrypoint.sh
@@ -51,6 +51,8 @@ elif [[ "$ENVIRONMENT" == "gcp" ]] || [[ "$ENVIRONMENT" == "GCP" ]]
 then
     export ENVIRONMENT="gcp"
 
+else
+    export ENVIRONMENT="default"
 fi
 
 # Test Optional Environment Variables

--- a/shared/shared/environments/cloud_environment.py
+++ b/shared/shared/environments/cloud_environment.py
@@ -109,4 +109,8 @@ class CloudEnvironments:
         Get the current Cloud Environment
         :return: (CloudEnvironment) The current cloud environments
         """
-        return CloudEnvironments.__dict__[env_vars['ENVIRONMENT']]
+        try:
+            ce = CloudEnvironments.__dict__[env_vars['ENVIRONMENT']]
+        except:
+            ce = CloudEnvironments.default
+        return ce


### PR DESCRIPTION
Handling new environments in bobby

## Description
In case we deploy to new environments, bobby needs to be able to handle that. This really just manages where you can deploy models to. So if a new environment (like `op`)

## Motivation and Context
SEC


## How Has This Been Tested?
Locally

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
