### PR TITLE
fix for advanced search

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       AIRFLOW_URL: "http://host.docker.internal:9876/api/v1"
       AIRFLOW_USER: airflow
       AIRFLOW_PASSWORD: airflow
-    image: splicemachine/sm_k8_feature_store:0.0.5_patch5
+    image: splicemachine/sm_k8_feature_store:0.0.5_patch6
     ports:
       - "8000:8000"
     build:

--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -761,7 +761,7 @@ def feature_search(db: Session, fs: schemas.FeatureSearch) -> List[schemas.Featu
     # If there's a better way to do this we should fix it
     for col, comp in fs:
         table = fset if col in ('schema_name', 'table_name', 'deployed') else f  # These columns come from feature set
-        if not comp:
+        if comp == None: # Because the comparitor may be "false" (ie deployed=False) but it's not None
             continue
         if type(comp) in (bool, str):  # No dictionary, simple comparison
             q = q.filter(getattr(table, col) == comp)


### PR DESCRIPTION
The deployed search flag was not working. This fixes that

## Description
When users passed in deployed=False to the search, it was returning all of the features and skipping the filter. This is because if deployed=`False` then the check of `if not deployed` will be true, which we don't want. We want to skip flags that are `None` (ie not passed in by the user). So we switch to `if comp != None`

## Motivation and Context
Bug fix



## How Has This Been Tested?
Against K8s

## Screenshots (if appropriate):

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
  - **BREAKING** note on base feature
  - Basically whatever formatting we have here, just plain-text
	%> command example
- next feature
  - note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Fixes
* Deployed flag on feature search

