### PR TITLE
Update mlmanager_2.8.0-k8.sql

### DIFF
--- a/releases/mlmanager_2.8.0-k8.sql
+++ b/releases/mlmanager_2.8.0-k8.sql
@@ -9,7 +9,7 @@ CREATE TABLE "MLMANAGER"."ARTIFACTS2" (
 ,"ARTIFACT_PATH" VARCHAR(250)
 ,"FILE_EXTENSION" VARCHAR(25)
 ,"DATABASE_BINARY" BLOB(2000000000)
-, CONSTRAINT ARTIFACT_PK2 PRIMARY KEY("RUN_UUID","NAME"), CONSTRAINT SQLB849C19605798BDC141A0004DDCB06F8 FOREIGN KEY ("RUN_UUID") REFERENCES "MLMANAGER"."RUNS"("RUN_UUID") ON UPDATE NO ACTION ON DELETE NO ACTION) ;
+, CONSTRAINT ARTIFACT_PK2 PRIMARY KEY("RUN_UUID","NAME"), CONSTRAINT fk_artifacts_runs FOREIGN KEY ("RUN_UUID") REFERENCES "MLMANAGER"."RUNS"("RUN_UUID") ON UPDATE NO ACTION ON DELETE NO ACTION) ;
 insert into mlmanager.artifacts2 (run_uuid, name, "size", "binary", file_extension, database_binary, artifact_path) select run_uuid, name, "size", "binary", file_extension, database_binary, artifact_path from mlmanager.artifacts;
 drop table mlmanager.artifacts;
 rename mlmanager.artifacts2 to artifacts;


### PR DESCRIPTION
It seems as though adding a column ad-hoc broke my running cluster (as it was listed in this table). Dropping and recreating the table with the right order of columns fixed the issue. I'm not sure if this needs to be applied to all of the tables moving forward for upgrades.

