### PR TITLE
Add ml-manager pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ node('dind-compose') {
           ])
        checkout([  
               $class: 'GitSCM', 
-              branches: [[name: '*/test']],
+              branches: [[name: '*/master']],
               doGenerateSubmoduleConfigurations: false, 
               extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ml-workflow']], 
               submoduleCfg: [], 
@@ -71,12 +71,14 @@ node('dind-compose') {
         dir('ml-workflow'){
             sh "nohup dockerd >/dev/null 2>&1 &"
             sh "docker-compose build mlflow bobby feature_store"
+            sh "docker-compose push mlflow bobby feature_store"
             sh  """
             git config --global user.email "build@splicemachine.com"
             git config --global user.name "cloudspliceci"
             git status
             git add docker-compose.yaml
             git commit -m 'Update image tag to ${BUILD_NUMBER}'
+            git push
             """
         }
     }
@@ -92,7 +94,7 @@ node('dind-compose') {
             git status
             git add \$(pwd)/kubernetes/charts/splice/values.yaml
             git commit -m 'Update image tag to ${BUILD_NUMBER}'
-            hub pull-request -m 'Update ml-manager image tags to ${BUILD_NUMBER}'
+            git push 
             """
 
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,113 @@
+// Define base params
+def git_username = "cloudspliceci"
+def git_email = "build@splicemachine.com"
+def vault_addr="https://vault.build.splicemachine-dev.io"
+
+// Launch the docker container
+node('dind') {
+
+    def dockerlogin = [
+        [$class: 'VaultSecret', path: "secret/team/docker_hub", secretValues: [
+            [$class: 'VaultSecretValue', envVar: 'username', vaultKey: 'username'],
+            [$class: 'VaultSecretValue', envVar: 'password', vaultKey: 'password']]]
+    ]
+
+    def gitlogin = [
+        [$class: 'VaultSecret', path: "secret/team/git_hub_ssh", secretValues: [
+            [$class: 'VaultSecretValue', envVar: 'git_ssh', vaultKey: 'id_rsa']]]
+    ]
+
+    def vaultlogin = [
+        [$class: 'VaultSecret', path: "secret/team/vault_jenkins", secretValues: [
+            [$class: 'VaultSecretValue', envVar: 'vault_token', vaultKey: 'token']]]
+    ]
+
+    environment {
+        VAULT_ADDR = "https://vault.build.splicemachine-dev.io"
+        VAULT_TOKEN = "$vault_token"
+    }
+
+    try {
+
+    notifyBuild('STARTED')
+
+    stage('Checkout') {
+      // Checkout code from repository
+      checkout([  
+              $class: 'GitSCM', 
+              branches: [[name: '*/dev']],
+              doGenerateSubmoduleConfigurations: false, 
+              extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'dbaas-infrastructure']], 
+              submoduleCfg: [], 
+              userRemoteConfigs: [[credentialsId: '88647ede-744a-444b-8c08-8313cc137944', url: 'https://github.com/splicemachine/dbaas-infrastructure.git']]
+          ])
+       checkout([  
+              $class: 'GitSCM', 
+              branches: [[name: '*/test']],
+              doGenerateSubmoduleConfigurations: false, 
+              extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'ml-workflow']], 
+              submoduleCfg: [], 
+              userRemoteConfigs: [[credentialsId: '88647ede-744a-444b-8c08-8313cc137944', url: 'https://github.com/splicemachine/ml-workflow.git']]
+          ])
+    }
+
+    
+    // Login to docker hub in the container
+    stage('Login') {
+        wrap([$class: 'VaultBuildWrapper', vaultSecrets: dockerlogin]) {
+            sh "docker login -u $username -p $password"
+        }
+    }
+
+    stage('Prep Image') {
+        dir('ml-workflow'){
+            sh """
+            sed -i 's/_DEV.*//' docker-compose.yaml 
+            sed -i 's/image: splicemachine\/sm_k8_mlflow:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            sed -i 's/image: splicemachine\/sm_k8_bobby:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            sed -i 's/image: splicemachine\/sm_k8_feature_store:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            cat docker-compose.yaml 
+            """
+        }
+    }
+    
+
+    stage('Build ML Images') {
+        dir('ml-workflow'){
+            sh "nohup dockerd >/dev/null 2>&1 &"
+            sh "docker-compose build mlflow bobby feature_store"
+        }
+    }
+
+    } catch (any) {
+        // if there was an exception thrown, the build failed
+        currentBuild.result = "FAILED"
+        throw any
+
+    } finally {
+
+        // success or failure, always send notifications
+        notifyBuild(currentBuild.result)
+    }
+}
+
+def notifyBuild(String buildStatus = 'STARTED') {
+    // Build status of null means successful.
+    buildStatus =  buildStatus ?: 'SUCCESSFUL'
+    // Override default values based on build status.
+    if (buildStatus == 'STARTED' || buildStatus == 'INPUT') {
+        color = 'YELLOW'
+        colorCode = '#FFFF00'
+    } else if (buildStatus == 'CREATING' || buildStatus == 'DESTROYING'){
+        color = 'BLUE'
+        colorCode = '#0000FF'
+    } else if (buildStatus == 'SUCCESSFUL') {
+        color = 'GREEN'
+        colorCode = '#00FF00'
+    } else if (buildStatus == 'FAILED'){
+        color = 'RED'
+        colorCode = '#FF0000'
+    } else {
+        echo "End of pipeline"
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,9 +63,9 @@ node('dind') {
         dir('ml-workflow'){
             sh """
             sed -i 's/_DEV.*//' docker-compose.yaml 
-            sed -i 's/image: splicemachine\\\/sm_k8_mlflow:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
-            sed -i 's/image: splicemachine\\\/sm_k8_bobby:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
-            sed -i 's/image: splicemachine\\\/sm_k8_feature_store:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            sed -i 's/image: splicemachine\\/sm_k8_mlflow:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            sed -i 's/image: splicemachine\\/sm_k8_bobby:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            sed -i 's/image: splicemachine\\/sm_k8_feature_store:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
             cat docker-compose.yaml 
             """
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,14 +81,13 @@ node('dind-compose') {
 
     stage('Edit dbaas-infrastructure') {
         dir('dbaas-infrastructure/dbaas-infrastructure/kubernetes/charts/splice/'){
-            sh """
-            python3 ../ml-workflow/update_tag.py $(pwd)/values.yaml
-            cat values.yaml 
-            git checkout -b update_ml_manager_${BUILD_NUMBER}
-            git status
-            git add values.yaml 
-            git commit -m 'Update image tag to ${BUILD_NUMBER}'
-            """
+            sh "python3 ../ml-workflow/update_tag.py $(pwd)/values.yaml"
+            sh "cat values.yaml"
+            sh "git checkout -b update_ml_manager_${BUILD_NUMBER}"
+            sh "git status"
+            sh "git add values.yaml"
+            sh "git commit -m 'Update image tag to ${BUILD_NUMBER}'"
+
         }
     }
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,10 +61,8 @@ node('dind-compose') {
 
     stage('Prep Image') {
         dir('ml-workflow'){
-            sh """
-            python3 update_tag.py $(pwd)/docker-compose.yaml 
-            cat docker-compose.yaml 
-            """
+            sh "python3 update_tag.py $(pwd)/docker-compose.yaml"
+            sh "cat docker-compose.yaml"
         }
     }
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ node('dind-compose') {
 
     stage('Prep Image') {
         dir('ml-workflow'){
-            sh "python3 update_tag.py $(pwd)/docker-compose.yaml"
+            sh "python3 update_tag.py \$(pwd)/docker-compose.yaml"
             sh "cat docker-compose.yaml"
         }
     }
@@ -79,7 +79,7 @@ node('dind-compose') {
 
     stage('Edit dbaas-infrastructure') {
         dir('dbaas-infrastructure/dbaas-infrastructure/kubernetes/charts/splice/'){
-            sh "python3 ../ml-workflow/update_tag.py $(pwd)/values.yaml"
+            sh "python3 ../ml-workflow/update_tag.py \$(pwd)/values.yaml"
             sh "cat values.yaml"
             sh "git checkout -b update_ml_manager_${BUILD_NUMBER}"
             sh "git status"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,9 +63,9 @@ node('dind') {
         dir('ml-workflow'){
             sh """
             sed -i 's/_DEV.*//' docker-compose.yaml 
-            sed -i 's/image: splicemachine\/sm_k8_mlflow:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
-            sed -i 's/image: splicemachine\/sm_k8_bobby:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
-            sed -i 's/image: splicemachine\/sm_k8_feature_store:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            sed -i 's/image: splicemachine\\\/sm_k8_mlflow:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            sed -i 's/image: splicemachine\\\/sm_k8_bobby:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
+            sed -i 's/image: splicemachine\\\/sm_k8_feature_store:.*/&_DEV_${BUILD_NUMBER}/' docker-compose.yaml 
             cat docker-compose.yaml 
             """
         }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       FRAMEWORK_NAME: my-framework
       MODE: development
       ENVIRONMENT: ${ENVIRONMENT:-default}
-    image: splicemachine/sm_k8_mlflow:0.1.31
+    image: splicemachine/sm_k8_mlflow:0.1.31_DEV5
     ports:
       - "5001:5001"
       - "5003:5003"
@@ -47,7 +47,7 @@ services:
       SAGEMAKER_ROLE: ${SAGEMAKER_ROLE}
       MODE: production
       ENVIRONMENT: ${ENVIRONMENT:-default}
-    image: splicemachine/sm_k8_bobby:0.1.31
+    image: splicemachine/sm_k8_bobby:0.1.31_DEV5
     build:
       args:
         server_image_tag: 0.0.15
@@ -68,7 +68,7 @@ services:
       AIRFLOW_URL: "http://host.docker.internal:9876/api/v1"
       AIRFLOW_USER: airflow
       AIRFLOW_PASSWORD: airflow
-    image: splicemachine/sm_k8_feature_store:0.0.5_patch7
+    image: splicemachine/sm_k8_feature_store:0.0.5_patch7_DEV5
     ports:
       - "8000:8000"
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
       FRAMEWORK_NAME: my-framework
       MODE: development
       ENVIRONMENT: ${ENVIRONMENT:-default}
-    image: splicemachine/sm_k8_mlflow:0.1.31_DEV5
+    image: splicemachine/sm_k8_mlflow:0.1.31
     ports:
       - "5001:5001"
       - "5003:5003"
@@ -47,7 +47,7 @@ services:
       SAGEMAKER_ROLE: ${SAGEMAKER_ROLE}
       MODE: production
       ENVIRONMENT: ${ENVIRONMENT:-default}
-    image: splicemachine/sm_k8_bobby:0.1.31_DEV5
+    image: splicemachine/sm_k8_bobby:0.1.31
     build:
       args:
         server_image_tag: 0.0.15
@@ -68,7 +68,7 @@ services:
       AIRFLOW_URL: "http://host.docker.internal:9876/api/v1"
       AIRFLOW_USER: airflow
       AIRFLOW_PASSWORD: airflow
-    image: splicemachine/sm_k8_feature_store:0.0.5_patch7_DEV5
+    image: splicemachine/sm_k8_feature_store:0.0.5_patch7
     ports:
       - "8000:8000"
     build:

--- a/update_tag.py
+++ b/update_tag.py
@@ -1,7 +1,8 @@
 from os import environ as env_vars
 import sys
 
-file_name = sys.argv[0]
+assert len(sys.argv) == 2, "You must provide a path to a file to edit. python update_tag.py /path/to/file"
+file_name = sys.argv[1]
 BUILD_NUMBER = env_vars['BUILD_NUMBER']
 newlines = []
 f = open(file_name).readlines()

--- a/update_tag.py
+++ b/update_tag.py
@@ -1,7 +1,10 @@
 from os import environ as env_vars
+import sys
+
+file_name = sys.argv[0]
 BUILD_NUMBER = env_vars['BUILD_NUMBER']
 newlines = []
-f = open('docker-compose.yaml').readlines()
+f = open(file_name).readlines()
 for line in f:
     newline = line.rstrip('\n')
     if 'sm_k8_mlflow' in line or 'sm_k8_bobby' in line or 'sm_k8_feature_store' in line:
@@ -10,5 +13,5 @@ for line in f:
         elif line[-1].isdigit:
             newline = newline[:-1] + str(BUILD_NUMBER)
     newlines.append(newline + "\n")
-with open('docker-compose.yaml', 'w+') as new_file:
+with open(file_name, 'w+') as new_file:
     new_file.writelines(newlines)

--- a/update_tag.py
+++ b/update_tag.py
@@ -1,0 +1,14 @@
+from os import environ as env_vars
+BUILD_NUMBER = env_vars['BUILD_NUMBER']
+newlines = []
+f = open('docker-compose.yaml').readlines()
+for line in f:
+    newline = line.rstrip('\n')
+    if 'sm_k8_mlflow' in line or 'sm_k8_bobby' in line or 'sm_k8_feature_store' in line:
+        if 'DEV' not in line:
+            newline = newline + f'_DEV{BUILD_NUMBER}'
+        elif line[-1].isdigit:
+            newline = newline[:-1] + str(BUILD_NUMBER)
+    newlines.append(newline + "\n")
+with open('docker-compose.yaml', 'w+') as new_file:
+    new_file.writelines(newlines)


### PR DESCRIPTION
## Description
Automated build/push docker images and push git changes

## Motivation and Context
Create an automated build/push docker pipeline. Added python file to append `_DEV` to the yaml files. The 3 associated ml-manager images are built and pushed with a `_DEV` tag.
The `update_tag.py` read the `BUILD_NUMBER` environment variable available from Jenkins. 
For the ml-workflow repo, there is a git commit pushed straight into master and for the dbaas-infrastructure, it creates a new branch of `update_ml_manager_${BUILD_NUMBER}`

## How Has This Been Tested?
https://jenkins.build.splicemachine-dev.io/job/SpliceImageBuilds/job/ml-manager/job/test/32/