### PR TITLE
DBAAS-5861: Feature's feature type is not validated on create

### DIFF
--- a/feature_store/src/rest_api/schemas.py
+++ b/feature_store/src/rest_api/schemas.py
@@ -25,6 +25,12 @@ class FeatureBase(FeatureMetadata):
     feature_data_type: DataType
     feature_type: str
 
+    @validator('feature_type')
+    def check_values(cls, v):
+        if v not in ('C', 'N', 'O'):
+            raise ValueError("Feature type must be one of ('C','N','O')")
+        return v
+
 class FeatureCreate(FeatureBase):
     pass
 


### PR DESCRIPTION
## Description
When we create a feature type, we don't validate that it's 'C' 'O' or 'N'. We need to validate that

## Motivation and Context
if the value passed in is more than 1 character, we get a truncation error on the feature_type column
Fixes [DBAAS-5861](https://splicemachine.atlassian.net/browse/DBAAS-5861)

## Dependencies
N/A

## How Has This Been Tested?
Tested locally on standalone

## Screenshots (if appropriate):

## Changelog Inclusions

### Additions
- Feature type validation on creation of feature

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
