### PR TITLE
DBAAS-5862: Remove feature set not checking case sensitivity

### DIFF
--- a/feature_store/src/rest_api/crud.py
+++ b/feature_store/src/rest_api/crud.py
@@ -783,7 +783,11 @@ def get_feature_sets(db: Session, feature_set_ids: List[int] = None, feature_set
                 q = q.join(mv, (fsv.feature_set_id == mv.c.feature_set_id) & (fsv.feature_set_version == mv.c.feature_set_version))
             else:
                 queries.append(fsv.feature_set_version == version)
-        queries.extend([getattr(fset, name) == value for name, value in _filter.items()])
+        for name, value in _filter.items():
+            if isinstance(value, str):
+                queries.append(func.upper(getattr(fset, name)) == value.upper())
+            else:
+                queries.append(getattr(fset, name) == value)
     else:
         d = db.query(models.FeatureSetVersion.feature_set_id.label('feature_set_id'), 
                     func.max(models.FeatureSetVersion.feature_set_version).label('feature_set_version')). \


### PR DESCRIPTION
## Description
Adds case insensitive checking to feature set names when getting/deleting

## Motivation and Context
If you create a feature set "foo.bar" you cannot remove it, because it is stored in the metadata with lowercase, but you compare with uppercase during remove. 
Fixes [DBAAS-5862](https://splicemachine.atlassian.net/browse/DBAAS-5862)

## Dependencies
N/A

## How Has This Been Tested?
Tested locally on standalone

## Screenshots (if appropriate):

## Changelog Inclusions

### Additions

### Changes

### Fixes
- Filters in `get_feature_set` are now case insensitive

### Deprecated

### Removed

### Breaking Changes
